### PR TITLE
Typo fix: openchain-license-compliance-3.0.md

### DIFF
--- a/3.0/en/openchain-license-compliance-3.0.md
+++ b/3.0/en/openchain-license-compliance-3.0.md
@@ -2,7 +2,7 @@
 
 ## Version 3.0
 
-This Specification is designed to provide an interation to ISO/IEC 5230:2020. It is currently a draft and is not ready for deployment.
+This Specification is designed to provide an iteration to ISO/IEC 5230:2020. It is currently a draft and is not ready for deployment.
 
 ## Contents
 


### PR DESCRIPTION
The first row typo fixed.